### PR TITLE
fix: Support additional `extends` package patterns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,28 @@ const resolveTsConfigFromFile = (cwd: string, filename: string) => {
 const resolveTsConfigFromExtends = (cwd: string, name: string) => {
   if (path.isAbsolute(name)) return fs.existsSync(name) ? name : null
   if (name.startsWith(".")) return findUp(name, cwd)
-  const id = req.resolve(name, { paths: [cwd] })
+  let id: string | null = null
+  try {
+    id = req.resolve(name, { paths: [cwd] })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND") {
+      // config package did _not_ use pkg.main field
+      const pkgJsonPath = req.resolve(path.join(name, "package.json"), {
+        paths: [cwd],
+      })
+      const pkgManifest = req(pkgJsonPath) as { tsconfig?: string }
+      // use explicit pkg.tsconfig or implicit "index" {pkgroot}/tsconfig.json
+      id = req.resolve(
+        path.join(
+          name,
+          pkgManifest.tsconfig ? pkgManifest.tsconfig : "tsconfig.json",
+        ),
+        { paths: [cwd] },
+      )
+    } else {
+      throw error
+    }
+  }
   return id
 }
 

--- a/test/fixtures/extends-package-explicit/no-extn.json
+++ b/test/fixtures/extends-package-explicit/no-extn.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig-pkg-explicit/other"
+}

--- a/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/explicit-tsconfig.json
+++ b/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/explicit-tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "files": ["explicit"]
+}

--- a/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/other.json
+++ b/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/other.json
@@ -1,0 +1,3 @@
+{
+    "files": ["other-file"]
+}

--- a/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/package.json
+++ b/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "tsconfig-pkg-explicit",
+    "tsconfig": "explicit-tsconfig.json"
+}

--- a/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/tsconfig.json
+++ b/test/fixtures/extends-package-explicit/node_modules/tsconfig-pkg-explicit/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "files": ["ignored in favor of pkg.tsconfig"]
+}

--- a/test/fixtures/extends-package-explicit/subpath.json
+++ b/test/fixtures/extends-package-explicit/subpath.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig-pkg-explicit/other.json"
+}

--- a/test/fixtures/extends-package-explicit/tsconfig.json
+++ b/test/fixtures/extends-package-explicit/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig-pkg-explicit"
+}

--- a/test/fixtures/extends-package-implicit/no-extn.json
+++ b/test/fixtures/extends-package-implicit/no-extn.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig-pkg-implicit/other"
+}

--- a/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/other/config.json
+++ b/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/other/config.json
@@ -1,0 +1,3 @@
+{
+    "files": ["other-directory-config"]
+}

--- a/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/other/tsconfig.json
+++ b/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/other/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "files": ["other-directory"]
+}

--- a/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/package.json
+++ b/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "tsconfig-pkg-implicit"
+}

--- a/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/tsconfig.json
+++ b/test/fixtures/extends-package-implicit/node_modules/tsconfig-pkg-implicit/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "files": ["implicit"]
+}

--- a/test/fixtures/extends-package-implicit/subpath.json
+++ b/test/fixtures/extends-package-implicit/subpath.json
@@ -1,0 +1,4 @@
+{
+  "extends": "tsconfig-pkg-implicit/other/config"
+}
+  

--- a/test/fixtures/extends-package-implicit/tsconfig.json
+++ b/test/fixtures/extends-package-implicit/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "tsconfig-pkg-implicit"
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -26,6 +26,16 @@ test("extends package", () => {
   ])
 })
 
+test("extends package with explicit tsconfig", () => {
+  const loaded = loadTsConfig(fixture("extends-package-explicit"))
+  expect(loaded?.data.files).toEqual(["explicit"])
+})
+
+test("extends package with implicit tsconfig", () => {
+  const loaded = loadTsConfig(fixture("extends-package-implicit"))
+  expect(loaded?.data.files).toEqual(["implicit"])
+})
+
 test("find nearest file", () => {
   expect(loadTsConfig(fixture("find-nearest/nested/dir"))).not.toBe(null)
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,9 +31,41 @@ test("extends package with explicit tsconfig", () => {
   expect(loaded?.data.files).toEqual(["explicit"])
 })
 
+test("extends package subpath file without extension", () => {
+  const loaded = loadTsConfig(
+    fixture("extends-package-explicit"),
+    "no-extn.json",
+  )
+  expect(loaded?.data.files).toEqual(["other-file"])
+})
+
+test("extends package subpath file with extension", () => {
+  const loaded = loadTsConfig(
+    fixture("extends-package-explicit"),
+    "subpath.json",
+  )
+  expect(loaded?.data.files).toEqual(["other-file"])
+})
+
 test("extends package with implicit tsconfig", () => {
   const loaded = loadTsConfig(fixture("extends-package-implicit"))
   expect(loaded?.data.files).toEqual(["implicit"])
+})
+
+test("extends package with implicit subpath directory", () => {
+  const loaded = loadTsConfig(
+    fixture("extends-package-implicit"),
+    "no-extn.json",
+  )
+  expect(loaded?.data.files).toEqual(["other-directory"])
+})
+
+test("extends package with implicit file subpath", () => {
+  const loaded = loadTsConfig(
+    fixture("extends-package-implicit"),
+    "subpath.json",
+  )
+  expect(loaded?.data.files).toEqual(["other-directory-config"])
 })
 
 test("find nearest file", () => {


### PR DESCRIPTION
I tried to use `tsup` in a project that extended a private package using `pkg.tsconfig` instead of `pkg.main` (implicit or explicit), and it blew up with a `MODULE_NOT_FOUND` error stack. Documentation on tsconfig packages is hard to find, so I ended up tracking down the [implementation PR](https://github.com/microsoft/TypeScript/pull/27348) to figure out what the "official" support entailed.

I split it into two commits mostly because the fix for my immediate problem was somewhat smaller. It's certainly appropriate to squash, if desired.