### PR TITLE
support module references in extends (checking default tsconfig.json filename)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,17 @@ const resolveTsConfigFromFile = (cwd: string, filename: string) => {
   return findUp(filename, cwd)
 }
 
-const resolveTsConfigFromExtends = (cwd: string, name: string) => {
+const resolveTsConfigFromExtends = (cwd: string, name: string) => {  
   if (path.isAbsolute(name)) return fs.existsSync(name) ? name : null
   if (name.startsWith(".")) return findUp(name, cwd)
-  const id = req.resolve(name, { paths: [cwd] })
-  return id
+  try {
+    const id = req.resolve(name, { paths: [cwd] })
+    return id
+  }
+  catch {
+    const id = req.resolve(name+'/tsconfig.json', { paths: [cwd] })
+    return id
+  }
 }
 
 export type Loaded = {


### PR DESCRIPTION
I noticed using `vitest` with `unplugin-swc` that loading `typescript` configuration fails when referencing a module without filename.

Typescript itself and `esbuild` allow extending a tsconfig that is references as a module or path, without a filename.

E.g. when a `tsconfig.json` file is exported in a node_module called `my-tsconfig-module` (for example in a monorepo where a tsconfig module is a workspace that's symlinked to other packages as a module dependency)

Then your tsconfig can reference it as:
```json
{
   "extends": "my-tsconfig-module"
}
```

And `typescript` will search for a `/my-tsconfig-module` dir in `node_modules` and look for a `tsconfig.json` file in it by default.

This PR adds a try / catch to handle this case.